### PR TITLE
Adding encoder and decoder for geometry

### DIFF
--- a/circe/shared/src/main/scala/com/monsanto/labs/mwundo/GeoJsonCodec.scala
+++ b/circe/shared/src/main/scala/com/monsanto/labs/mwundo/GeoJsonCodec.scala
@@ -61,6 +61,8 @@ object GeoJsonCodec {
   }
 
   implicit val toGeometryDecoder: Decoder[GeoJson.Geometry] = Decoder.instance[Geometry]{ cursor =>
+    import cats.syntax.either._
+
     cursor.downField("type").as[String].toTry.map{
       case "Polygon" => cursor.as[GeoJson.Polygon]
       case "MultiPolygon" => cursor.as[MultiPolygon]

--- a/circe/shared/src/test/scala/com/monsanto/labs/mwundo/GeoJsonCodecTest.scala
+++ b/circe/shared/src/test/scala/com/monsanto/labs/mwundo/GeoJsonCodecTest.scala
@@ -10,7 +10,6 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 class GeoJsonCodecTest extends FunSpec with Matchers with ParallelTestExecution {
 
   import GeoJsonCodec._
-  import cats.syntax.either._
 
   private def marshalAndUnmarshal[T](t: T)(implicit encoder: Encoder[T], decoder: Decoder[T]) = {
     val json = t.asJson
@@ -381,6 +380,36 @@ class GeoJsonCodecTest extends FunSpec with Matchers with ParallelTestExecution 
       val featureWithoutId = Feature(GeoJson.Point(Coordinate(1, 1)), MyProps("hi de ho"))
 
       marshalAndUnmarshal(featureWithoutId)
+    }
+
+    it("should marshal and unmarshal a geometry"){
+
+      val polygon: Geometry = Polygon(Seq(
+        Seq(Coordinate(0.1, 2.0), Coordinate(1.1, 2.1)),
+        Seq(Coordinate(0.1, 2.0), Coordinate(1.1, 2.1))
+      ))
+
+      marshalAndUnmarshal(polygon)
+    }
+
+    it("should marshal and unmarshal geometries"){
+      val multiPolygon = MultiPolygon(Seq(
+        Seq(
+          Seq(Coordinate(0.1, 2.0), Coordinate(1.1, 2.1)),
+          Seq(Coordinate(0.1, 2.0), Coordinate(1.1, 2.1))),
+        Seq(
+          Seq(Coordinate(0.1, 2.0), Coordinate(1.1, 2.1)),
+          Seq(Coordinate(0.1, 2.0), Coordinate(1.1, 2.1)))
+      ))
+
+      val polygon = Polygon(Seq(
+        Seq(Coordinate(0.1, 2.0), Coordinate(1.1, 2.1)),
+        Seq(Coordinate(0.1, 2.0), Coordinate(1.1, 2.1))
+      ))
+
+      val geometries: Seq[Geometry] = Seq(multiPolygon, polygon)
+
+      marshalAndUnmarshal(geometries)
     }
 
   }

--- a/circe/shared/src/test/scala/com/monsanto/labs/mwundo/GeoJsonCodecTest.scala
+++ b/circe/shared/src/test/scala/com/monsanto/labs/mwundo/GeoJsonCodecTest.scala
@@ -8,7 +8,7 @@ import io.circe.parser._
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 class GeoJsonCodecTest extends FunSpec with Matchers with ParallelTestExecution {
-
+  import cats.syntax.either._
   import GeoJsonCodec._
 
   private def marshalAndUnmarshal[T](t: T)(implicit encoder: Encoder[T], decoder: Decoder[T]) = {


### PR DESCRIPTION
- Adding encoder and decoder for geometries, previously it wasn't possible to read or write Geometries. For instance, it wasn't possible to read a geojson that contained an array of MultiPolygons and Polygons, even though its valid geojson.