### PR TITLE
Change coordinate primitive to Double from BigDecimal

### DIFF
--- a/circe/shared/src/main/scala/com/monsanto/labs/mwundo/GeoJsonCodec.scala
+++ b/circe/shared/src/main/scala/com/monsanto/labs/mwundo/GeoJsonCodec.scala
@@ -21,8 +21,8 @@ object GeoJsonCodec {
 
   implicit val coordinateDecoder: Decoder[GeoJson.Coordinate] = Decoder.instance { cursor =>
     cursor.as[Array[Double]] match {
-      case Right(coords) if coords.length == 2 => Right(Coordinate(coords(0), coords(1)))
-      case _ => Left(DecodingFailure("Decoding error.  Coordinates must be an 'x' and a 'y' in array form.", cursor.history))
+      case Right(coords) if coords.length == 2 || coords.length == 3 => Right(Coordinate(coords(0), coords(1)))
+      case _ => Left(DecodingFailure("Decoding error.  Coordinates must be an 'x' and a 'y' or 'x', 'y', 'z' in array form.", cursor.history))
     }
   }
 

--- a/circe/shared/src/main/scala/com/monsanto/labs/mwundo/GeoJsonCodec.scala
+++ b/circe/shared/src/main/scala/com/monsanto/labs/mwundo/GeoJsonCodec.scala
@@ -16,11 +16,11 @@ object GeoJsonCodec {
   import com.monsanto.labs.mwundo.GeoJson._
 
   implicit val coordinateEncoder: Encoder[GeoJson.Coordinate] = Encoder.instance { coordinate =>
-    Array[BigDecimal](coordinate.x, coordinate.y).asJson
+    Array[Double](coordinate.x, coordinate.y).asJson
   }
 
   implicit val coordinateDecoder: Decoder[GeoJson.Coordinate] = Decoder.instance { cursor =>
-    cursor.as[Array[BigDecimal]] match {
+    cursor.as[Array[Double]] match {
       case Right(coords) if coords.length == 2 => Right(Coordinate(coords(0), coords(1)))
       case _ => Left(DecodingFailure("Decoding error.  Coordinates must be an 'x' and a 'y' in array form.", cursor.history))
     }

--- a/circe/shared/src/test/scala/com/monsanto/labs/mwundo/GeoJsonCodecPropTest.scala
+++ b/circe/shared/src/test/scala/com/monsanto/labs/mwundo/GeoJsonCodecPropTest.scala
@@ -47,8 +47,8 @@ object GeoJsonGenerators {
   implicit val arbMultiPolygon: Arbitrary[MultiPolygon] = Arbitrary(genMultiPolygon)
 
   def genCoordinate: Gen[Coordinate] = for {
-    x <- arbitrary[BigDecimal]
-    y <- arbitrary[BigDecimal]
+    x <- arbitrary[Double]
+    y <- arbitrary[Double]
   } yield Coordinate(x, y)
 
   def genCoordinateSeq: Gen[Seq[Coordinate]] = Gen.nonEmptyContainerOf[Seq, Coordinate](genCoordinate)

--- a/circe/shared/src/test/scala/com/monsanto/labs/mwundo/GeoJsonCodecTest.scala
+++ b/circe/shared/src/test/scala/com/monsanto/labs/mwundo/GeoJsonCodecTest.scala
@@ -152,6 +152,16 @@ class GeoJsonCodecTest extends FunSpec with Matchers with ParallelTestExecution 
       coordinate should be (Coordinate(0.1, 2.0))
     }
 
+    it("should unmarshal coordinates with length of 3"){
+
+      val jsonArrayAsString = "[1.0,2.0,0.1]"
+
+      val jsonArray = parse(jsonArrayAsString).right.get
+      val coordinate = jsonArray.as[Coordinate].right.get
+
+      coordinate should be (Coordinate(1.0, 2.0))
+    }
+
     it("should NOT convert a JSON Array of size 0 to a Coordinate") {
       val jsonArrayAsString = "[]"
 
@@ -168,13 +178,14 @@ class GeoJsonCodecTest extends FunSpec with Matchers with ParallelTestExecution 
       jsonArray.as[Coordinate].toTry.isFailure should be (true)
     }
 
-    it("should NOT convert a JSON Array of size greater than 2 to a Coordinate") {
-      val jsonArrayAsString = "[0.1,0.1,0.1]"
+    it("should NOT convert a JSON Array of size greater than 3 to a Coordinate") {
+      val jsonArrayAsString = "[0.1,0.1,0.1,0.1]"
 
       val jsonArray = parse(jsonArrayAsString).right.get
 
       jsonArray.as[Coordinate].toTry.isFailure should be (true)
     }
+
 
     it("should marshal and unmarshal Coordinate") {
       val coordinate = Coordinate(0.1, 2.0)

--- a/core/jvm/src/main/scala/com/monsanto/labs/mwundo/GeoJsonImplicits.scala
+++ b/core/jvm/src/main/scala/com/monsanto/labs/mwundo/GeoJsonImplicits.scala
@@ -188,7 +188,7 @@ object GeoJsonImplicits {
      */
     def centroid: Coordinate = {
       val centroid = asJTS.getCentroid.getCoordinate
-      Coordinate(BigDecimal(centroid.x), BigDecimal(centroid.y))
+      Coordinate(centroid.x, centroid.y)
     }
 
     /**

--- a/core/shared/src/main/scala/com/monsanto/labs/mwundo/GeoJson.scala
+++ b/core/shared/src/main/scala/com/monsanto/labs/mwundo/GeoJson.scala
@@ -12,7 +12,7 @@ object GeoJson {
 
   sealed trait Coords[+A] {val coordinates: A}
 
-  case class Coordinate(x: BigDecimal, y: BigDecimal)
+  case class Coordinate(x: Double, y: Double)
 
   case class Point(coordinates: Coordinate) extends Geometry with Coords[Coordinate] {
     override val `type`: String = "Point"

--- a/spray/src/main/scala/com/monsanto/labs/mwundo/GeoJsonFormats.scala
+++ b/spray/src/main/scala/com/monsanto/labs/mwundo/GeoJsonFormats.scala
@@ -18,7 +18,7 @@ object GeoJsonFormats extends DefaultJsonProtocol {
 
     def read(json: JsValue): Coordinate = json match {
       case JsArray(is) if is.length == 2 =>
-        Coordinate(is(0).convertTo[BigDecimal], is(1).convertTo[BigDecimal])
+        Coordinate(is(0).convertTo[Double], is(1).convertTo[Double])
       case _ => deserializationError(s"'$json' is not a valid Coordinate")
     }
   }

--- a/spray/src/main/scala/com/monsanto/labs/mwundo/GeoJsonFormats.scala
+++ b/spray/src/main/scala/com/monsanto/labs/mwundo/GeoJsonFormats.scala
@@ -17,7 +17,7 @@ object GeoJsonFormats extends DefaultJsonProtocol {
     )
 
     def read(json: JsValue): Coordinate = json match {
-      case JsArray(is) if is.length == 2 =>
+      case JsArray(is) if is.length == 2 || is.length == 3 =>
         Coordinate(is(0).convertTo[Double], is(1).convertTo[Double])
       case _ => deserializationError(s"'$json' is not a valid Coordinate")
     }

--- a/spray/src/test/scala/com/monsanto/labs/mwundo/GeoJsonFormatPropTest.scala
+++ b/spray/src/test/scala/com/monsanto/labs/mwundo/GeoJsonFormatPropTest.scala
@@ -59,8 +59,8 @@ object GeoJsonGenerators {
   implicit def arbGeometryCollection[T <: Geometry]: Arbitrary[GeometryCollection[T]] = Arbitrary(genGeometryCollection[T])
 
   def genCoordinate: Gen[Coordinate] = for {
-    x <- arbitrary[BigDecimal]
-    y <- arbitrary[BigDecimal]
+    x <- arbitrary[Double]
+    y <- arbitrary[Double]
   } yield Coordinate(x, y)
 
   def genCoordinateSeq: Gen[Seq[Coordinate]] = Gen.nonEmptyContainerOf[Seq, Coordinate](genCoordinate)

--- a/spray/src/test/scala/com/monsanto/labs/mwundo/GeoJsonFormatTest.scala
+++ b/spray/src/test/scala/com/monsanto/labs/mwundo/GeoJsonFormatTest.scala
@@ -225,5 +225,16 @@ class GeoJsonFormatTest extends FunSpec with Matchers with ParallelTestExecution
 
       marshalAndUnmarshal(f)
     }
+
+    it("should unmarshal coordinates with Z"){
+
+      "[1.0, 2.0, 0.0]".parseJson.convertTo[Coordinate] shouldEqual Coordinate(1.0, 2.0)
+    }
+
+
+    it("should not unmarshal coordinates with length > 3"){
+
+      assertThrows[DeserializationException]("[1.0, 2.0, 0.0, 0.0]".parseJson.convertTo[Coordinate])
+    }
   }
 }


### PR DESCRIPTION
BigDecimal is not being used internally for computation or used in JTS or Java2d. It adds additional overhead to parsing / serialization. This change does break backwards compatibility. 

GeoJSON Spec
https://tools.ietf.org/html/rfc7946#page-18

In addition, currently mwundo outputs dangerous geojson as there is no guarantee that consumer outside of mwundo will be able to handle a number with more precision.

Also, this adds support for parsing geojsons that have the optional 3rd value in a point
https://tools.ietf.org/html/rfc7946#section-3.1.1
