### PR TITLE
Upgrade JTS to 1.16

### DIFF
--- a/core/src/main/scala/com/monsanto/labs/mwundo/GeoJsonImplicits.scala
+++ b/core/src/main/scala/com/monsanto/labs/mwundo/GeoJsonImplicits.scala
@@ -1,7 +1,7 @@
 package com.monsanto.labs.mwundo
 
 import com.monsanto.labs.mwundo.GeoJson.{Coordinate, Feature, FeatureCollection}
-import com.vividsolutions.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.GeometryFactory
 
 /**
  * Bounding box used to wrap GeoJson shapes so various area calculations can be performed
@@ -66,7 +66,7 @@ object GeoJsonImplicits {
 
     /**
      * convert geometry to JTS format
-     * @return com.vividsolutions.jts.geom.Geometry
+     * @return org.locationtech.jts.geom.Geometry
      */
     def asJTS = jtsGeoFormat.toJTSGeo(geometry, RichGeoJsonFeature.geoFac)
 

--- a/core/src/main/scala/com/monsanto/labs/mwundo/JTSGeoFormat.scala
+++ b/core/src/main/scala/com/monsanto/labs/mwundo/JTSGeoFormat.scala
@@ -1,7 +1,7 @@
 package com.monsanto.labs.mwundo
 
-import com.vividsolutions.jts.geom._
-import com.vividsolutions.jts.geom.impl.CoordinateArraySequence
+import org.locationtech.jts.geom._
+import org.locationtech.jts.geom.impl.CoordinateArraySequence
 
 /**
  * Created by Ryan Richt on 10/26/15

--- a/core/src/main/scala/com/monsanto/labs/mwundo/JTSGeometryImplicits.scala
+++ b/core/src/main/scala/com/monsanto/labs/mwundo/JTSGeometryImplicits.scala
@@ -1,6 +1,6 @@
 package com.monsanto.labs.mwundo
 
-import com.vividsolutions.jts.geom.Geometry
+import org.locationtech.jts.geom.Geometry
 
 object JTSGeometryImplicits {
   implicit class RichJTSGeometry(geom: Geometry){

--- a/core/src/main/scala/com/monsanto/labs/mwundo/Java2Dable.scala
+++ b/core/src/main/scala/com/monsanto/labs/mwundo/Java2Dable.scala
@@ -2,7 +2,7 @@ package com.monsanto.labs.mwundo
 
 import java.awt.geom.Point2D
 
-import com.vividsolutions.jts.awt.PolygonShape
+import org.locationtech.jts.awt.PolygonShape
 
 /**
  * Created by Ryan Richt on 10/26/15

--- a/core/src/main/scala/com/monsanto/labs/mwundo/Utils.scala
+++ b/core/src/main/scala/com/monsanto/labs/mwundo/Utils.scala
@@ -1,6 +1,6 @@
 package com.monsanto.labs.mwundo
 
-import com.vividsolutions.jts.geom._
+import org.locationtech.jts.geom._
 import collection.JavaConverters._
 
 /**

--- a/core/src/test/scala/com/monsanto/labs/mwundo/GeometryClipper_UT.scala
+++ b/core/src/test/scala/com/monsanto/labs/mwundo/GeometryClipper_UT.scala
@@ -1,9 +1,9 @@
 package com.monsanto.labs.mwundo
 
 //import com.monsanto.labs.sim.agriculture.distributions.BetaDistribution2D
-//import com.vividsolutions.jts.geom.impl.CoordinateArraySequence
-//import com.vividsolutions.jts.geom.{GeometryCollection, Envelope, Coordinate, GeometryFactory}
-//import com.vividsolutions.jts.triangulate.VoronoiDiagramBuilder
+//import org.locationtech.jts.geom.impl.CoordinateArraySequence
+//import org.locationtech.jts.geom.{GeometryCollection, Envelope, Coordinate, GeometryFactory}
+//import org.locationtech.jts.triangulate.VoronoiDiagramBuilder
 //import org.scalatest.{Matchers, FunSpec}
 
 //import collection.JavaConverters._

--- a/core/src/test/scala/com/monsanto/labs/mwundo/GeometryCollection_UT.scala
+++ b/core/src/test/scala/com/monsanto/labs/mwundo/GeometryCollection_UT.scala
@@ -1,8 +1,8 @@
 package com.monsanto.labs.mwundo
 
-import com.vividsolutions.jts.geom.impl.CoordinateArraySequence
+import org.locationtech.jts.geom.impl.CoordinateArraySequence
 import org.scalatest.{Matchers, FunSpec}
-import com.vividsolutions.jts.geom._
+import org.locationtech.jts.geom._
 import collection.JavaConverters._
 //import JTSGeometryImplicits._
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   private val breeze = "0.13"
 
   lazy val core = Seq(
-    "com.vividsolutions" %  "jts-core"       % "1.14.0",
+    "org.locationtech.jts" %  "jts-core"       % "1.16.0",
     // -- breeze --
     "org.scalanlp"       %% "breeze"         % breeze,
     "org.scalanlp"       %% "breeze-natives" % breeze


### PR DESCRIPTION
This upgrades JTS to 1.16, but the change in package names may have devastating impacts downstream. This is needed for geotools v20.0.

What's the best path forward?